### PR TITLE
Remove obsolete Python 3.13 requirements file

### DIFF
--- a/fashion_finder_fixed/README-WINDOWS.md
+++ b/fashion_finder_fixed/README-WINDOWS.md
@@ -39,8 +39,9 @@ If you prefer to install manually, follow these steps:
 
 2. **Install Python Dependencies**
    ```
-   pip install flask flask-cors flask-session pandas scikit-learn
+   pip install -r requirements.txt
    ```
+   > **Note**: The old `requirements_python313.txt` file is no longer used.
 
 3. **Create Required Directories**
    ```

--- a/fashion_finder_fixed/README.md
+++ b/fashion_finder_fixed/README.md
@@ -85,7 +85,7 @@ fashion_finder/
 3. Install backend dependencies:
    ```
    pip install -r requirements.txt
-   ```
+> **Note**: All Python dependencies are listed in `requirements.txt`. The obsolete `requirements_python313.txt` file was removed.
 
 ### Running the Application
 

--- a/fashion_finder_fixed/requirements_python313.txt
+++ b/fashion_finder_fixed/requirements_python313.txt
@@ -1,1 +1,0 @@
-venv\Scripts\activate 


### PR DESCRIPTION
## Summary
- remove `requirements_python313.txt`
- document that only `requirements.txt` is used
- update Windows install guide to use `requirements.txt`

## Testing
- `pip install --dry-run -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_6846d9b81d448325b9bd81a252f10082